### PR TITLE
Fix JSHint errors in the generated gulpfile.js

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -1,16 +1,14 @@
+'use strict';
+
 var gulp = require('gulp'),
-    wiredep = require('wiredep').stream,
     browserSync = require('browser-sync'),
     reload = browserSync.reload,
-    useref = require('gulp-useref'),
     gulpif = require('gulp-if'),
     uglify = require('gulp-uglify'),
     minifyCss = require('gulp-minify-css'),
-    merge = require('merge-stream'),
     browserify = require('browserify'),
     source = require('vinyl-source-stream'),
     buffer = require('vinyl-buffer'),
-    gutil = require('gulp-util'),
     sourcemaps = require('gulp-sourcemaps'),
     isProduction = (process.env.ENV === 'production');
 

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -4,18 +4,14 @@
   "dependencies": {
 	  "gulp": "^3.8.11",
 	  "browser-sync": "^2.2.1",
-	  "wiredep": "^2.2.2",
-	  "gulp-useref": "^1.1.1",
 	  "main-bower-files": "^2.5.0",
 	  "gulp-if": "^1.2.5",
 	  "gulp-uglify": "^1.1.0",
 	  "gulp-minify-css": "^1.0.0",
 	  "del": "^1.1.1",
-	  "merge-stream": "^0.1.7",
 	  "browserify": "^10.2.4",
 	  "babylonjs": "^2.3.0",
 	  "gulp-sourcemaps": "^1.5.2",
-	  "gulp-util": "^3.0.6",
 	  "vinyl-buffer": "^1.0.0",
 	  "vinyl-source-stream": "^1.1.0"
   }


### PR DESCRIPTION
Mostly this means removing unneeded dependencies from #2 and adding a 'use strict'; statement.